### PR TITLE
Adding patch for kernel 5.9

### DIFF
--- a/kernel-5.9.patch
+++ b/kernel-5.9.patch
@@ -1,0 +1,88 @@
+diff -Naur a/kernel/nv.c b/kernel/nv.c
+--- a/kernel/nv.c	2020-08-26 14:28:09.350000000 +0200
++++ b/kernel/nv.c	2020-08-26 14:35:42.856666666 +0200
+@@ -2785,8 +2785,12 @@
+ 
+ #if defined(CONFIG_VGA_ARB)
+ #if defined(VGA_DEFAULT_DEVICE)
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 9, 0)
++    vga_get(VGA_DEFAULT_DEVICE, VGA_RSRC_LEGACY_MASK, 0);
++#else
+     vga_tryget(VGA_DEFAULT_DEVICE, VGA_RSRC_LEGACY_MASK);
+ #endif
++#endif
+     vga_set_legacy_decoding(dev, VGA_RSRC_NONE);
+ #endif
+ 
+diff -Naur a/kernel/nv-drm.c b/kernel/nv-drm.c
+--- a/kernel/nv-drm.c	2020-08-26 14:28:09.506666667 +0200
++++ b/kernel/nv-drm.c	2020-08-26 14:48:58.443333335 +0200
+@@ -373,7 +373,11 @@
+     .set_busid = drm_pci_set_busid,
+ #endif
+ 
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 9, 0)
++    .gem_free_object_unlocked = nv_gem_free,
++#else
+     .gem_free_object = nv_gem_free,
++#endif
+ 
+     .prime_handle_to_fd = drm_gem_prime_handle_to_fd,
+     .gem_prime_export = drm_gem_prime_export,
+@@ -470,8 +474,12 @@
+ #if defined(NV_DRM_GEM_OBJECT_PUT_UNLOCKED_PRESENT)
+     drm_gem_object_put_unlocked(&nv_obj->base);
+ #else
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 9, 0)
++    drm_gem_object_put_locked(&nv_obj->base);
++#else
+     drm_gem_object_unreference_unlocked(&nv_obj->base);
+ #endif
++#endif
+ 
+     status = RM_OK;
+ 
+diff -Naur a/kernel/nv-linux.h b/kernel/nv-linux.h
+--- a/kernel/nv-linux.h	2020-08-26 14:28:09.583333333 +0200
++++ b/kernel/nv-linux.h	2020-08-26 14:53:45.693333299 +0200
+@@ -136,8 +136,10 @@
+ 
+ #if defined(NVCPU_X86_64) && !defined(HAVE_COMPAT_IOCTL)
+ #include <linux/syscalls.h>         /* sys_ioctl()                      */
++#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 9, 0)
+ #include <linux/ioctl32.h>          /* register_ioctl32_conversion()    */
+ #endif
++#endif
+ 
+ #if !defined(NV_FILE_OPERATIONS_HAS_IOCTL) && \
+   !defined(NV_FILE_OPERATIONS_HAS_UNLOCKED_IOCTL)
+@@ -2249,10 +2251,13 @@
+                                             pages, vmas, NULL);
+ 
+         #else
+-
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 9, 0)
++               return get_user_pages_remote(mm, start, nr_pages, flags,
++                                            pages, vmas, NULL);
++#else
+                return get_user_pages_remote(tsk, mm, start, nr_pages, flags,
+                                             pages, vmas);
+-
++#endif
+         #endif
+ 
+         }
+diff -Naur a/kernel/uvm/nvidia_uvm_linux.h b/kernel/uvm/nvidia_uvm_linux.h
+--- a/kernel/uvm/nvidia_uvm_linux.h	2019-12-11 23:04:24.000000000 +0100
++++ b/kernel/uvm/nvidia_uvm_linux.h	2020-10-18 20:13:35.701550371 +0200
+@@ -158,8 +158,10 @@
+ 
+ #if defined(NVCPU_X86_64) && !defined(HAVE_COMPAT_IOCTL)
+ #include <linux/syscalls.h>         /* sys_ioctl()                      */
++#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 9, 0)
+ #include <linux/ioctl32.h>          /* register_ioctl32_conversion()    */
+ #endif
++#endif
+ 
+ #if !defined(NV_FILE_OPERATIONS_HAS_IOCTL) && \
+   !defined(NV_FILE_OPERATIONS_HAS_UNLOCKED_IOCTL)

--- a/nvidia-340xx-kmod.spec
+++ b/nvidia-340xx-kmod.spec
@@ -22,6 +22,7 @@ Source11:      nvidia-kmodtool-excludekernel-filterfile
 Patch0:        nv-linux-arm.patch
 Patch1:        kernel-5.7.patch
 Patch2:        kernel-5.8.patch
+Patch3:        kernel-5.9.patch
 
 BuildRequires: elfutils-libelf-devel
 BuildRequires: gcc
@@ -50,6 +51,7 @@ tar --use-compress-program xz -xf %{_datadir}/%{name}-%{version}/%{name}-%{versi
 # patch loop
 %patch1 -p1
 %patch2 -p1
+%patch3 -p1
 %patch0 -p1
 
 for kernel_version  in %{?kernel_versions} ; do
@@ -80,6 +82,9 @@ done
 %{?akmod_install}
 
 %changelog
+* Thu Oct 19 2020 Thaison Nguyen <thieson08@me.com> - 1:340.108-7
+- Patch for kernel-5.9.0
+
 * Wed Aug 12 2020 Leigh Scott <leigh123linux@gmail.com> - 1:340.108-6
 - Patch for kernel-5.8.0
 

--- a/nvidia-340xx-kmod.spec
+++ b/nvidia-340xx-kmod.spec
@@ -82,7 +82,7 @@ done
 %{?akmod_install}
 
 %changelog
-* Thu Oct 19 2020 Thaison Nguyen <thieson08@me.com> - 1:340.108-7
+* Thu Nov 19 2020 Thaison Nguyen <thieson08@me.com> - 1:340.108-7
 - Patch for kernel-5.9.0
 
 * Wed Aug 12 2020 Leigh Scott <leigh123linux@gmail.com> - 1:340.108-6


### PR DESCRIPTION
Copied patch from here:
https://github.com/warpme/minimyth2/blob/master/script/nvidia/nvidia-340.108/files/nvidia-340.108-fix-5.9-kernel-compile.patch