### PR TITLE
Patch for kernel-5.10.0

### DIFF
--- a/kernel-5.10.patch
+++ b/kernel-5.10.patch
@@ -1,0 +1,16 @@
+diff -Naur NVIDIA-Linux-x86_64-340.108-old/kernel/nv-drm.c NVIDIA-Linux-x86_64-340.108-new/kernel/nv-drm.c
+--- NVIDIA-Linux-x86_64-340.108-old/kernel/nv-drm.c	2020-12-13 19:10:56.759999937 +0100
++++ NVIDIA-Linux-x86_64-340.108-new/kernel/nv-drm.c	2020-12-13 19:09:02.039999925 +0100
+@@ -322,8 +322,11 @@
+ {
+     struct nv_gem_object *nv_obj = container_of(obj, struct nv_gem_object, base);
+     int page_count = obj->size >> PAGE_SHIFT;
+-
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 10, 0)
++    return drm_prime_pages_to_sg(obj->dev, nv_obj->pages, page_count);
++#else
+     return drm_prime_pages_to_sg(nv_obj->pages, page_count);
++#endif
+ }
+ 
+ static void* nv_gem_prime_vmap(

--- a/nvidia-340xx-kmod.spec
+++ b/nvidia-340xx-kmod.spec
@@ -12,7 +12,7 @@ Name:          nvidia-340xx-kmod
 Epoch:         1
 Version:       340.108
 # Taken over by kmodtool
-Release:       8%{?dist}
+Release:       9%{?dist}
 Summary:       NVIDIA display driver kernel module
 Group:         System Environment/Kernel
 License:       Redistributable, no modification permitted
@@ -23,6 +23,7 @@ Patch0:        nv-linux-arm.patch
 Patch1:        kernel-5.7.patch
 Patch2:        kernel-5.8.patch
 Patch3:        kernel-5.9.patch
+Patch4:        kernel-5.10.patch
 
 BuildRequires: elfutils-libelf-devel
 BuildRequires: gcc
@@ -52,6 +53,7 @@ tar --use-compress-program xz -xf %{_datadir}/%{name}-%{version}/%{name}-%{versi
 %patch1 -p1
 %patch2 -p1
 %patch3 -p1
+%patch4 -p1
 %patch0 -p1
 
 for kernel_version  in %{?kernel_versions} ; do
@@ -82,6 +84,9 @@ done
 %{?akmod_install}
 
 %changelog
+* Mon Dec 21 2020 Łukasz Wojniłowicz <lukasz.wojnilowicz@gmail.com> - 1:340.108-9
+- Patch for kernel-5.10.0
+
 * Tue Dec  8 2020 Thaison Nguyen <thieson08@me.com> - 1:340.108-8
 - rebuilt with rpmdev-bumpspec -D
 


### PR DESCRIPTION
Patch downloaded from
https://github.com/warpme/minimyth2/blob/master/script/nvidia/nvidia-340.108/files/nvidia-340.108-fix-5.10-kernel-compile.patch